### PR TITLE
Rewrite Flyfiles

### DIFF
--- a/big.file/fly/flyfile.js
+++ b/big.file/fly/flyfile.js
@@ -1,4 +1,3 @@
-exports.default = function* () {
-  yield this.source([ 'src/js/*.js' ])
-            .target('dist/js')
+exports.default = function* (f) {
+	yield f.source('src/js/*.js').target('dist/js')
 }

--- a/big.file/fly/flyfile.js
+++ b/big.file/fly/flyfile.js
@@ -1,3 +1,3 @@
-exports.default = function* (f) {
-	yield f.source('src/js/*.js').target('dist/js')
+exports.default = function* (fly) {
+	yield fly.source('src/js/*.js').target('dist/js')
 }

--- a/simple/fly/flyfile.js
+++ b/simple/fly/flyfile.js
@@ -1,13 +1,11 @@
-exports.js = function* () {
-  yield this.source([ 'src/js/*.js' ])
-            .target('dist/js')
-}
-
-exports.css = function* () {
-  yield this.source([ 'src/css/*.css' ])
-            .target('dist/css')
-}
-
-exports.default = function* () {
-  yield this.parallel(['js', 'css'])
+module.exports = {
+	*js(f) {
+		yield f.source('src/js/*.js').target('dist/js')
+	},
+	*css(f) {
+		yield f.source('src/css/*.css').target('dist/css')
+	},
+	*default(f) {
+		yield f.parallel(['js', 'css'])
+	}
 }

--- a/simple/fly/flyfile.js
+++ b/simple/fly/flyfile.js
@@ -1,11 +1,11 @@
 module.exports = {
-	*js(f) {
-		yield f.source('src/js/*.js').target('dist/js')
+	*js(fly) {
+		yield fly.source('src/js/*.js').target('dist/js')
 	},
-	*css(f) {
-		yield f.source('src/css/*.css').target('dist/css')
+	*css(fly) {
+		yield fly.source('src/css/*.css').target('dist/css')
 	},
-	*default(f) {
-		yield f.parallel(['js', 'css'])
+	*default(fly) {
+		yield fly.parallel(['js', 'css'])
 	}
 }

--- a/tons.of.big.files/fly/flyfile.js
+++ b/tons.of.big.files/fly/flyfile.js
@@ -1,4 +1,3 @@
-exports.default = function* () {
-  yield this.source([ 'src/js/*.js' ])
-            .target('dist/js')
+exports.default = function* (f) {
+	yield f.source('src/js/*.js').target('dist/js')
 }

--- a/tons.of.big.files/fly/flyfile.js
+++ b/tons.of.big.files/fly/flyfile.js
@@ -1,3 +1,3 @@
-exports.default = function* (f) {
-	yield f.source('src/js/*.js').target('dist/js')
+exports.default = function* (fly) {
+	yield fly.source('src/js/*.js').target('dist/js')
 }

--- a/tons.of.files/fly/flyfile.js
+++ b/tons.of.files/fly/flyfile.js
@@ -1,4 +1,3 @@
-exports.default = function* () {
-  yield this.source([ 'src/js/*.js' ])
-            .target('dist/js')
+exports.default = function* (f) {
+	yield f.source('src/js/*.js').target('dist/js')
 }

--- a/tons.of.files/fly/flyfile.js
+++ b/tons.of.files/fly/flyfile.js
@@ -1,3 +1,3 @@
-exports.default = function* (f) {
-	yield f.source('src/js/*.js').target('dist/js')
+exports.default = function* (fly) {
+	yield fly.source('src/js/*.js').target('dist/js')
 }


### PR DESCRIPTION
As of 2.0, there's a soft-deprecation on using `this` within tasks.

Also, uses the shortened object format when multiple tasks are defined.